### PR TITLE
[FC-2087] Move null one field lower

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ fn xform_meta(meta: Metadata, args: &ParsedArgs) -> Result<Vec<SourceUnit>> {
                 .repo(Some(args.repo.clone()))
                 .files(get_source_files(package_dir, &reference_path.as_path())?)
                 .deps(Some(get_direct_deps(&this_package, &meta, package_dir)?))
-                .data(this_package.license.to_owned().map(Into::<License>::into))
+                .data(this_package.license.to_owned().into())
                 .build()
                 .map_err(|e| anyhow!(e))?)
         })

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 #[derive(Debug, Clone, PartialOrd, PartialEq, Serialize)]
 pub struct License {
     #[serde(rename = "License")]
-    value: String,
+    value: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialOrd, PartialEq, Serialize, Builder)]
@@ -27,7 +27,7 @@ pub struct SourceUnit {
     deps: Option<Vec<ResolvedDependency>>,
 
     #[serde(rename = "Data")]
-    data: Option<License>,
+    data: License,
 }
 
 #[derive(Debug, Clone, PartialOrd, PartialEq, Serialize, Builder)]
@@ -60,8 +60,8 @@ pub struct ResolvedDependency {
     platform: Option<String>,
 }
 
-impl From<String> for License {
-    fn from(value: String) -> Self {
+impl From<Option<String>> for License {
+    fn from(value: Option<String>) -> Self {
         Self { value }
     }
 }


### PR DESCRIPTION
FC-2087

This issue was caused by simply not knowing that the position of the null in this case actually matters.

This PR changes the types which form the JSON serializer to match the expected output.

Test Plan:
run master branch version against env_logger, compare total output with this branch, only difference should be the desired difference.  (note that I have already done this as part of the dev tests)